### PR TITLE
Vbox rancher

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -381,7 +381,7 @@ func (d *Driver) Create() error {
 
 	d.InstanceId = instance.InstanceId
 
-	log.Debug("waiting for ip address to become available")
+	log.Infof("waiting for ip address to become available")
 	if err := utils.WaitFor(d.instanceIpAvailable); err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (d *Driver) Create() error {
 
 	d.waitForInstance()
 
-	log.Debugf("created instance ID %s, IP address %s, Private IP address %s",
+	log.Infof("created instance ID %s, IP address %s, Private IP address %s",
 		d.InstanceId,
 		d.IPAddress,
 		d.PrivateIPAddress,

--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -109,6 +109,7 @@ func (h *Host) Create(name string) error {
 
 	// TODO: Not really a fan of just checking "none" here.
 	if h.Driver.DriverName() != "none" {
+		log.Infof("Waiting for SSH")
 		if err := WaitForSSH(h); err != nil {
 			return err
 		}
@@ -336,7 +337,7 @@ func (h *Host) SaveConfig() error {
 
 func sshAvailableFunc(h *Host) func() bool {
 	return func() bool {
-		log.Debug("Getting to WaitForSSH function...")
+		log.Debugf("Getting to WaitForSSH function...")
 		hostname, err := h.Driver.GetSSHHostname()
 		if err != nil {
 			log.Debugf("Error getting IP address waiting for SSH: %s", err)

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -189,3 +189,7 @@ func (provisioner *Boot2DockerProvisioner) SSHCommand(args string) (ssh.Output, 
 func (provisioner *Boot2DockerProvisioner) GetDriver() drivers.Driver {
 	return provisioner.Driver
 }
+
+func (provisioner *Boot2DockerProvisioner) GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (ssh.Output, error) {
+	return provisioner.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", engineOptions, engineOptionsPath))
+}

--- a/libmachine/provision/os_release.go
+++ b/libmachine/provision/os_release.go
@@ -29,7 +29,7 @@ type OsRelease struct {
 }
 
 func stripQuotes(val string) string {
-	if val[0] == '"' {
+	if len(val) > 0 && val[0] == '"' {
 		return val[1 : len(val)-1]
 	}
 	return val

--- a/libmachine/provision/provisioner.go
+++ b/libmachine/provision/provisioner.go
@@ -21,6 +21,9 @@ type Provisioner interface {
 	// Get the directory where the settings files for docker are to be found
 	GetDockerOptionsDir() string
 
+	// Get the Command to set the docker engine config
+	GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (ssh.Output, error)
+
 	// Run a package action e.g. install
 	Package(name string, action pkgaction.PackageAction) error
 

--- a/libmachine/provision/rancher.go
+++ b/libmachine/provision/rancher.go
@@ -1,0 +1,156 @@
+package provision
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path"
+	"text/template"
+
+	"github.com/docker/machine/drivers"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/provision/pkgaction"
+	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/ssh"
+)
+
+const (
+	rancherTmpl = `user_docker:
+  tls: true
+  tls_args: [--tlsverify, --tlscacert={{ .CaCertPath }}, --tlscert={{ .ServerCertPath }}, --tlskey={{ .ServerKeyPath }},'-H=0.0.0.0:{{ .DockerPort }}']
+  args: [docker, -d, -s, overlay, -G, docker, -H, 'unix://']`
+)
+
+var (
+	ErrUnsupportedService = errors.New("unsupported service")
+)
+
+type RancherConfig struct {
+	CaCertPath     string
+	ServerCertPath string
+	ServerKeyPath  string
+	DockerPort     int
+}
+
+func init() {
+	Register("rancheros", &RegisteredProvisioner{
+		New: NewRancherProvisioner,
+	})
+}
+
+func NewRancherProvisioner(d drivers.Driver) Provisioner {
+	return &RancherProvisioner{
+		Driver: d,
+	}
+}
+
+type RancherProvisioner struct {
+	OsReleaseInfo *OsRelease
+	Driver        drivers.Driver
+	SwarmOptions  swarm.SwarmOptions
+}
+
+func (provisioner *RancherProvisioner) Service(name string, action pkgaction.ServiceAction) error {
+	var err error
+
+	switch action {
+	case pkgaction.Start:
+		_, err = provisioner.SSHCommand("sudo docker -H unix:///var/run/system-docker.sock start userdocker")
+	case pkgaction.Stop:
+		_, err = provisioner.SSHCommand("sudo docker -H unix:///var/run/system-docker.sock stop userdocker")
+	default:
+		return ErrUnsupportedService
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *RancherProvisioner) Package(name string, action pkgaction.PackageAction) error {
+	return nil
+}
+
+func (provisioner *RancherProvisioner) Hostname() (string, error) {
+	out, err := provisioner.SSHCommand(fmt.Sprintf("hostname"))
+	if err != nil {
+		return "", err
+	}
+
+	var so bytes.Buffer
+	if _, err := so.ReadFrom(out.Stdout); err != nil {
+		return "", err
+	}
+
+	return so.String(), nil
+}
+
+func (provisioner *RancherProvisioner) SetHostname(hostname string) error {
+	_, err := provisioner.SSHCommand(fmt.Sprintf(
+		"sudo hostname -b %s",
+		hostname,
+	))
+
+	return err
+}
+
+func (provisioner *RancherProvisioner) GetDockerOptionsDir() string {
+	return "/var/lib/rancher"
+}
+
+func (provisioner *RancherProvisioner) GenerateDockerOptions(dockerPort int, authOptions auth.AuthOptions) (*DockerOptions, error) {
+	var buf bytes.Buffer
+	cfg := &RancherConfig{
+		CaCertPath:     authOptions.CaCertRemotePath,
+		ServerCertPath: authOptions.ServerCertRemotePath,
+		ServerKeyPath:  authOptions.ServerKeyRemotePath,
+		DockerPort:     dockerPort,
+	}
+
+	t := template.Must(template.New("rancher").Parse(rancherTmpl))
+	t.Execute(&buf, cfg)
+	daemonCfg := buf.String()
+	daemonOptsDir := path.Join(provisioner.GetDockerOptionsDir(), "conf", "rancher.yml")
+	return &DockerOptions{
+		EngineOptions:     daemonCfg,
+		EngineOptionsPath: daemonOptsDir,
+	}, nil
+}
+
+func (provisioner *RancherProvisioner) CompatibleWithHost() bool {
+	return provisioner.OsReleaseInfo.Id == "rancheros"
+}
+
+func (provisioner *RancherProvisioner) SetOsReleaseInfo(info *OsRelease) {
+	provisioner.OsReleaseInfo = info
+}
+
+func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions) error {
+	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		return err
+	}
+
+	if err := installDockerGeneric(provisioner); err != nil {
+		return err
+	}
+
+	if err := ConfigureAuth(provisioner, authOptions); err != nil {
+		return err
+	}
+
+	if err := configureSwarm(provisioner, swarmOptions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *RancherProvisioner) SSHCommand(command string) (ssh.Output, error) {
+	return drivers.RunSSHCommandFromDriver(provisioner.Driver, command)
+}
+
+func (provisioner *RancherProvisioner) GetDriver() drivers.Driver {
+	return provisioner.Driver
+}

--- a/libmachine/provision/rancher.go
+++ b/libmachine/provision/rancher.go
@@ -154,3 +154,7 @@ func (provisioner *RancherProvisioner) SSHCommand(command string) (ssh.Output, e
 func (provisioner *RancherProvisioner) GetDriver() drivers.Driver {
 	return provisioner.Driver
 }
+
+func (provisioner *RancherProvisioner) GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (ssh.Output, error) {
+	return provisioner.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", engineOptions, engineOptionsPath))
+}

--- a/libmachine/provision/rancher.go
+++ b/libmachine/provision/rancher.go
@@ -89,7 +89,7 @@ func (provisioner *RancherProvisioner) Hostname() (string, error) {
 
 func (provisioner *RancherProvisioner) SetHostname(hostname string) error {
 	_, err := provisioner.SSHCommand(fmt.Sprintf(
-		"sudo hostname -b %s",
+		"sudo hostname -s %s",
 		hostname,
 	))
 

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -170,3 +170,7 @@ func (provisioner *UbuntuProvisioner) GenerateDockerOptions(dockerPort int, auth
 func (provisioner *UbuntuProvisioner) GetDriver() drivers.Driver {
 	return provisioner.Driver
 }
+
+func (provisioner *UbuntuProvisioner) GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (ssh.Output, error) {
+	return provisioner.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", engineOptions, engineOptionsPath))
+}

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -158,7 +158,7 @@ func ConfigureAuth(p Provisioner, authOptions auth.AuthOptions) error {
 		return err
 	}
 
-	if _, err = p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	if _, err = p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -158,7 +158,8 @@ func ConfigureAuth(p Provisioner, authOptions auth.AuthOptions) error {
 		return err
 	}
 
-	if _, err = p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	_, err = p.GetDockerEnginerConfigCmd(dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
@ibuildthecloud @sheng-liang 

The changes required for this were

1. Configure 2 network interfaces (eth0, eth1)
2. Do not append auth info into rancher.yml
3. Set user as "rancher"
4. Autoformat "boot2docker, please format-me" containing drive
5. Download machine-rancheros.iso

build docker machine

`make build`

Here's the iso I use (https://drive.google.com/file/d/0B23oeH8TXZJvWjlpOUlnMnhoSDQ/view?usp=sharing). You can specify the iso by setting the enviroment variable 

`VIRTUALBOX_RANCHER_URL=file://$(path-to-iso)`

and then use this command
` ./docker-machine_linux-amd64 create --driver virtualbox --virtualbox-use-rancher-os ranchervb1`